### PR TITLE
compatible with sequencer v0.3.0

### DIFF
--- a/estimate_electricity_cost_by_technology_from_population.py
+++ b/estimate_electricity_cost_by_technology_from_population.py
@@ -37,7 +37,7 @@ from infrastructure_planning.electricity.cost.grid import (
 
 from networker.networker_runner import NetworkerRunner
 from sequencer import NetworkPlan
-from sequencer.Models import EnergyMaximizeReturn
+from sequencer import Sequencer
 
 
 def assemble_total_mv_line_network(
@@ -108,7 +108,7 @@ def sequence_total_mv_line_network(target_folder, infrastructure_graph):
     nwp = NetworkPlan.from_files(
         edge_shapefile_path, node_table_path, prioritize='population',
         proj='+proj=longlat +datum=WGS84 +no_defs')
-    model = EnergyMaximizeReturn(nwp)
+    model = Sequencer(nwp, 'peak.demand.in.kw')
     model.sequence()
     order_series = model.output_frame['Sequence..Far.sighted.sequence']
     for index, order in order_series.iteritems():


### PR DESCRIPTION
To support legacy usage of sequencer and simplify things a bit, I parameterized the demand field by which to sequence things and got rid of the EnergyMaximizeReturn model (now uses Sequencer directly).  

New usage example here:
https://github.com/SEL-Columbia/sequencer/blob/v0.3.0/run_sequencer.py#L82

(note that I mimic @invisibleroads method for taking args from cmd line OR json config)

I see that work is happening in branch 2.2.0, so feel free to redirect this PR there.
